### PR TITLE
Migration

### DIFF
--- a/bancho/dm-commands/invite.js
+++ b/bancho/dm-commands/invite.js
@@ -23,7 +23,7 @@ module.exports = {
 				teams: {
 					some: {
 						Team: {
-							members: {
+							Members: {
 								some: {
 									user: {
 										osu_username: username,

--- a/bancho/match-types/bracket/Match.js
+++ b/bancho/match-types/bracket/Match.js
@@ -101,7 +101,7 @@ class MatchManager {
 		for (let team of dbTeams) {
 			let users = await prisma.user.findMany({
 				where: {
-					in_teams: {
+					inTeams: {
 						some: {
 							teamId: team.id,
 						},

--- a/bancho/match-types/bracket/Match.js
+++ b/bancho/match-types/bracket/Match.js
@@ -479,7 +479,7 @@ class MatchManager {
 		let user = team.getUserPos(host?.user?.id);
 		if (user != undefined || user != null) return;
 
-		if (team.warmedUp) {
+		if (team.warmed_up) {
 			await this.lobby.clearHost();
 			await this.updateState(5);
 			await this.roll();

--- a/bancho/match-types/bracket/Match.js
+++ b/bancho/match-types/bracket/Match.js
@@ -85,7 +85,7 @@ class MatchManager {
 		// Make team objects from db
 		let dbTeams = await prisma.team.findMany({
 			where: {
-				TeamInMatch: {
+				InBracketMatches: {
 					some: {
 						matchId: this.id,
 					},

--- a/bancho/match-types/bracket/Team.js
+++ b/bancho/match-types/bracket/Team.js
@@ -43,7 +43,7 @@ class Team {
 		this.roll = team.roll;
 		this.ban_order = team.ban_order;
 		this.pick_order = team.pick_order;
-		this.warmedUp = team.warmedUp;
+		this.warmedUp = team.warmed_up;
 		this.score = team.score;
 
 		// let picks = await prisma.mapInMatch.findMany({
@@ -180,7 +180,7 @@ class Team {
 	 * @param {boolean} b
 	 */
 	async setWarmedUp(b) {
-		this.warmedUp = b;
+		this.warmed_up = b;
 		await new Promise((resolve) => setTimeout(resolve, prismaTimeout));
 		await prisma.teamInMatch.update({
 			where: {
@@ -190,7 +190,7 @@ class Team {
 				},
 			},
 			data: {
-				warmedUp: b,
+				warmed_up: b,
 			},
 		});
 	}

--- a/discord/buttons/invite_accept.js
+++ b/discord/buttons/invite_accept.js
@@ -17,7 +17,7 @@ module.exports = {
 		});
 		let team = await prisma.team.findFirst({
 			where: {
-				members: {
+				Members: {
 					some: {
 						discordId: command.options.user,
 					},

--- a/discord/buttons/match_start_list.js
+++ b/discord/buttons/match_start_list.js
@@ -95,7 +95,7 @@ module.exports = {
 		for (let match of group) {
 			let teams = await prisma.team.findMany({
 				where: {
-					TeamInMatch: {
+					InBracketMatches: {
 						some: {
 							matchId: match.id,
 						},

--- a/discord/buttons/start_match.js
+++ b/discord/buttons/start_match.js
@@ -110,7 +110,7 @@ module.exports = {
 		messageChannel = messageChannel || interaction.channel;
 		let players = await prisma.user.findMany({
 			where: {
-				in_teams: {
+				inTeams: {
 					some: {
 						Team: {
 							TeamInMatch: {

--- a/discord/buttons/start_match.js
+++ b/discord/buttons/start_match.js
@@ -30,7 +30,7 @@ module.exports = {
 		// Get the teams in the match
 		let teams = await prisma.team.findMany({
 			where: {
-				TeamInMatch: {
+				InBracketMatches: {
 					some: {
 						matchId: parseInt(command.options.id),
 					},
@@ -113,7 +113,7 @@ module.exports = {
 				inTeams: {
 					some: {
 						Team: {
-							TeamInMatch: {
+							InBracketMatches: {
 								some: {
 									matchId: match.id,
 								},

--- a/discord/buttons/team_list.js
+++ b/discord/buttons/team_list.js
@@ -27,7 +27,7 @@ module.exports = {
 		for (const team of teams) {
 			let membersInTeam = await prisma.user.findMany({
 				where: {
-					in_teams: {
+					inTeams: {
 						some: {
 							teamId: team.id,
 						},
@@ -106,7 +106,7 @@ module.exports = {
 			let teamString = "";
 			let members = await prisma.user.findMany({
 				where: {
-					in_teams: {
+					inTeams: {
 						some: {
 							teamId: team.id,
 						},

--- a/discord/buttons/view_match.js
+++ b/discord/buttons/view_match.js
@@ -43,7 +43,7 @@ module.exports = {
 			let teamString = "";
 			let members = await prisma.user.findMany({
 				where: {
-					in_teams: {
+					inTeams: {
 						some: {
 							teamId: team.id,
 						},

--- a/discord/buttons/view_match.js
+++ b/discord/buttons/view_match.js
@@ -18,7 +18,7 @@ module.exports = {
 			where: { roundId: round.id, id: parseInt(command.options.id) },
 		});
 		let teams = await prisma.team.findMany({
-			where: { TeamInMatch: { some: { matchId: match.id } } },
+			where: { InBracketMatches: { some: { matchId: match.id } } },
 		});
 
 		let back = new MessageActionRow().addComponents([

--- a/discord/commands/deregister.js
+++ b/discord/commands/deregister.js
@@ -13,7 +13,7 @@ module.exports = {
 
 		let team = await prisma.team.findFirst({
 			where: {
-				members: {
+				Members: {
 					some: {
 						discordId: interaction.user.id,
 					},

--- a/discord/commands/deregister.js
+++ b/discord/commands/deregister.js
@@ -32,7 +32,7 @@ module.exports = {
 		}
 		let members = await prisma.user.findMany({
 			where: {
-				in_teams: {
+				inTeams: {
 					some: {
 						teamId: team.id,
 					},

--- a/discord/commands/match/addlink.js
+++ b/discord/commands/match/addlink.js
@@ -26,7 +26,7 @@ module.exports = {
 				teams: {
 					some: {
 						Team: {
-							members: {
+							Members: {
 								some: {
 									discordId: interaction.user.id,
 								},

--- a/discord/commands/matches/create.js
+++ b/discord/commands/matches/create.js
@@ -205,7 +205,7 @@ module.exports = {
 			let teamString = "";
 			let members = await prisma.user.findMany({
 				where: {
-					in_teams: {
+					inTeams: {
 						some: {
 							teamId: team.id,
 						},

--- a/discord/commands/matches/create.js
+++ b/discord/commands/matches/create.js
@@ -57,7 +57,7 @@ module.exports = {
 			await prisma.team.findFirst({
 				where: {
 					tournamentId: tournament.id,
-					members: {
+					Members: {
 						some: {
 							discordId: users[0].id,
 						},
@@ -67,7 +67,7 @@ module.exports = {
 			await prisma.team.findFirst({
 				where: {
 					tournamentId: tournament.id,
-					members: {
+					Members: {
 						some: {
 							discordId: users[1].id,
 						},

--- a/discord/commands/register.js
+++ b/discord/commands/register.js
@@ -22,7 +22,7 @@ module.exports = {
 		let duplicateCheck = await prisma.team.findFirst({
 			where: {
 				tournamentId: tournament.id,
-				members: {
+				Members: {
 					some: {
 						discordId: interaction.user.id,
 					},

--- a/discord/commands/team/edit.js
+++ b/discord/commands/team/edit.js
@@ -34,7 +34,7 @@ module.exports = {
 
 		let team = await prisma.team.findFirst({
 			where: {
-				members: {
+				Members: {
 					some: {
 						discordId: interaction.user.id,
 					},

--- a/discord/commands/team/edit.js
+++ b/discord/commands/team/edit.js
@@ -137,7 +137,7 @@ module.exports = {
 
 		let members = await prisma.user.findMany({
 			where: {
-				in_teams: {
+				inTeams: {
 					some: {
 						teamId: team.id,
 					},

--- a/discord/commands/team/invite.js
+++ b/discord/commands/team/invite.js
@@ -69,7 +69,7 @@ module.exports = {
 
 		let inviterMembers = await prisma.user.findMany({
 			where: {
-				in_teams: {
+				inTeams: {
 					some: {
 						teamId: inviterTeam.id,
 					},
@@ -101,7 +101,7 @@ module.exports = {
 		let duplicateCheck = await prisma.user.findFirst({
 			where: {
 				discord_id: invitee.id,
-				in_teams: {
+				inTeams: {
 					some: {
 						discordId: invitee.id,
 						teamId: inviterTeam.id,

--- a/discord/commands/team/invite.js
+++ b/discord/commands/team/invite.js
@@ -27,7 +27,7 @@ module.exports = {
 		});
 		let inviteeTeam = await prisma.team.findFirst({
 			where: {
-				members: {
+				Members: {
 					some: {
 						discordId: invitee.id,
 					},
@@ -44,7 +44,7 @@ module.exports = {
 		});
 		let inviterTeam = await prisma.team.findFirst({
 			where: {
-				members: {
+				Members: {
 					some: {
 						discordId: interaction.user.id,
 					},

--- a/discord/commands/team/view.js
+++ b/discord/commands/team/view.js
@@ -17,7 +17,7 @@ module.exports = {
 
 		let team = await prisma.team.findFirst({
 			where: {
-				members: {
+				Members: {
 					some: {
 						discordId: user.id,
 					},

--- a/discord/commands/team/view.js
+++ b/discord/commands/team/view.js
@@ -46,7 +46,7 @@ module.exports = {
 
 		let members = await prisma.user.findMany({
 			where: {
-				in_teams: {
+				inTeams: {
 					some: {
 						teamId: team.id,
 					},

--- a/prisma/migrations/20220516000841_ahr/migration.sql
+++ b/prisma/migrations/20220516000841_ahr/migration.sql
@@ -1,0 +1,21 @@
+-- CreateTable
+CREATE TABLE "AutoHostRotate" (
+    "discordId" TEXT NOT NULL PRIMARY KEY,
+    "min_stars" INTEGER,
+    "max_stars" INTEGER,
+    "min_length" INTEGER,
+    "max_length" INTEGER,
+    "min_rank" INTEGER,
+    "max_rank" INTEGER,
+    CONSTRAINT "AutoHostRotate_discordId_fkey" FOREIGN KEY ("discordId") REFERENCES "User" ("discord_id") ON DELETE RESTRICT ON UPDATE CASCADE
+);
+
+-- CreateTable
+CREATE TABLE "AutoHostRotatePlayer" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "username" TEXT NOT NULL,
+    "rank" INTEGER NOT NULL,
+    "lobbyId" TEXT NOT NULL,
+    "host" BOOLEAN NOT NULL DEFAULT false,
+    CONSTRAINT "AutoHostRotatePlayer_lobbyId_fkey" FOREIGN KEY ("lobbyId") REFERENCES "AutoHostRotate" ("discordId") ON DELETE RESTRICT ON UPDATE CASCADE
+);

--- a/prisma/migrations/20220516001254_ahr/migration.sql
+++ b/prisma/migrations/20220516001254_ahr/migration.sql
@@ -1,0 +1,24 @@
+/*
+  Warnings:
+
+  - Added the required column `mp_link` to the `AutoHostRotate` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- RedefineTables
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_AutoHostRotate" (
+    "discordId" TEXT NOT NULL PRIMARY KEY,
+    "mp_link" TEXT NOT NULL,
+    "min_stars" INTEGER,
+    "max_stars" INTEGER,
+    "min_length" INTEGER,
+    "max_length" INTEGER,
+    "min_rank" INTEGER,
+    "max_rank" INTEGER,
+    CONSTRAINT "AutoHostRotate_discordId_fkey" FOREIGN KEY ("discordId") REFERENCES "User" ("discord_id") ON DELETE RESTRICT ON UPDATE CASCADE
+);
+INSERT INTO "new_AutoHostRotate" ("discordId", "max_length", "max_rank", "max_stars", "min_length", "min_rank", "min_stars") SELECT "discordId", "max_length", "max_rank", "max_stars", "min_length", "min_rank", "min_stars" FROM "AutoHostRotate";
+DROP TABLE "AutoHostRotate";
+ALTER TABLE "new_AutoHostRotate" RENAME TO "AutoHostRotate";
+PRAGMA foreign_key_check;
+PRAGMA foreign_keys=ON;

--- a/prisma/migrations/20220516013304_ahr/migration.sql
+++ b/prisma/migrations/20220516013304_ahr/migration.sql
@@ -1,0 +1,22 @@
+/*
+  Warnings:
+
+  - The primary key for the `AutoHostRotatePlayer` table will be changed. If it partially fails, the table could be left without primary key constraint.
+  - You are about to alter the column `id` on the `AutoHostRotatePlayer` table. The data in that column could be lost. The data in that column will be cast from `String` to `Int`.
+
+*/
+-- RedefineTables
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_AutoHostRotatePlayer" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "username" TEXT NOT NULL,
+    "rank" INTEGER NOT NULL,
+    "lobbyId" TEXT NOT NULL,
+    "host" BOOLEAN NOT NULL DEFAULT false,
+    CONSTRAINT "AutoHostRotatePlayer_lobbyId_fkey" FOREIGN KEY ("lobbyId") REFERENCES "AutoHostRotate" ("discordId") ON DELETE RESTRICT ON UPDATE CASCADE
+);
+INSERT INTO "new_AutoHostRotatePlayer" ("host", "id", "lobbyId", "rank", "username") SELECT "host", "id", "lobbyId", "rank", "username" FROM "AutoHostRotatePlayer";
+DROP TABLE "AutoHostRotatePlayer";
+ALTER TABLE "new_AutoHostRotatePlayer" RENAME TO "AutoHostRotatePlayer";
+PRAGMA foreign_key_check;
+PRAGMA foreign_keys=ON;

--- a/prisma/migrations/20220516013836_ahl/migration.sql
+++ b/prisma/migrations/20220516013836_ahl/migration.sql
@@ -1,0 +1,36 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `host` on the `AutoHostRotatePlayer` table. All the data in the column will be lost.
+
+*/
+-- RedefineTables
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_AutoHostRotatePlayer" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "username" TEXT NOT NULL,
+    "rank" INTEGER NOT NULL,
+    "lobbyId" TEXT NOT NULL,
+    CONSTRAINT "AutoHostRotatePlayer_lobbyId_fkey" FOREIGN KEY ("lobbyId") REFERENCES "AutoHostRotate" ("discordId") ON DELETE RESTRICT ON UPDATE CASCADE
+);
+INSERT INTO "new_AutoHostRotatePlayer" ("id", "lobbyId", "rank", "username") SELECT "id", "lobbyId", "rank", "username" FROM "AutoHostRotatePlayer";
+DROP TABLE "AutoHostRotatePlayer";
+ALTER TABLE "new_AutoHostRotatePlayer" RENAME TO "AutoHostRotatePlayer";
+CREATE TABLE "new_AutoHostRotate" (
+    "discordId" TEXT NOT NULL PRIMARY KEY,
+    "mp_link" TEXT NOT NULL,
+    "min_stars" INTEGER,
+    "max_stars" INTEGER,
+    "min_length" INTEGER,
+    "max_length" INTEGER,
+    "min_rank" INTEGER,
+    "max_rank" INTEGER,
+    "currentHostId" INTEGER,
+    CONSTRAINT "AutoHostRotate_discordId_fkey" FOREIGN KEY ("discordId") REFERENCES "User" ("discord_id") ON DELETE RESTRICT ON UPDATE CASCADE,
+    CONSTRAINT "AutoHostRotate_currentHostId_fkey" FOREIGN KEY ("currentHostId") REFERENCES "AutoHostRotatePlayer" ("id") ON DELETE SET NULL ON UPDATE CASCADE
+);
+INSERT INTO "new_AutoHostRotate" ("discordId", "max_length", "max_rank", "max_stars", "min_length", "min_rank", "min_stars", "mp_link") SELECT "discordId", "max_length", "max_rank", "max_stars", "min_length", "min_rank", "min_stars", "mp_link" FROM "AutoHostRotate";
+DROP TABLE "AutoHostRotate";
+ALTER TABLE "new_AutoHostRotate" RENAME TO "AutoHostRotate";
+PRAGMA foreign_key_check;
+PRAGMA foreign_keys=ON;

--- a/prisma/migrations/20220516014430_ahr/migration.sql
+++ b/prisma/migrations/20220516014430_ahr/migration.sql
@@ -1,0 +1,14 @@
+-- RedefineTables
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_AutoHostRotatePlayer" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "username" TEXT NOT NULL,
+    "rank" INTEGER NOT NULL,
+    "lobbyId" TEXT NOT NULL,
+    CONSTRAINT "AutoHostRotatePlayer_lobbyId_fkey" FOREIGN KEY ("lobbyId") REFERENCES "AutoHostRotate" ("discordId") ON DELETE CASCADE ON UPDATE CASCADE
+);
+INSERT INTO "new_AutoHostRotatePlayer" ("id", "lobbyId", "rank", "username") SELECT "id", "lobbyId", "rank", "username" FROM "AutoHostRotatePlayer";
+DROP TABLE "AutoHostRotatePlayer";
+ALTER TABLE "new_AutoHostRotatePlayer" RENAME TO "AutoHostRotatePlayer";
+PRAGMA foreign_key_check;
+PRAGMA foreign_keys=ON;

--- a/prisma/migrations/20220516035509_ahr/migration.sql
+++ b/prisma/migrations/20220516035509_ahr/migration.sql
@@ -1,0 +1,28 @@
+/*
+  Warnings:
+
+  - You are about to alter the column `max_stars` on the `AutoHostRotate` table. The data in that column could be lost. The data in that column will be cast from `Int` to `Float`.
+  - You are about to alter the column `min_stars` on the `AutoHostRotate` table. The data in that column could be lost. The data in that column will be cast from `Int` to `Float`.
+
+*/
+-- RedefineTables
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_AutoHostRotate" (
+    "discordId" TEXT NOT NULL PRIMARY KEY,
+    "mp_link" TEXT NOT NULL,
+    "min_stars" REAL,
+    "max_stars" REAL,
+    "min_length" INTEGER,
+    "max_length" INTEGER,
+    "min_rank" INTEGER,
+    "max_rank" INTEGER,
+    "currentHostId" INTEGER,
+    CONSTRAINT "AutoHostRotate_discordId_fkey" FOREIGN KEY ("discordId") REFERENCES "User" ("discord_id") ON DELETE RESTRICT ON UPDATE CASCADE,
+    CONSTRAINT "AutoHostRotate_currentHostId_fkey" FOREIGN KEY ("currentHostId") REFERENCES "AutoHostRotatePlayer" ("id") ON DELETE SET NULL ON UPDATE CASCADE
+);
+INSERT INTO "new_AutoHostRotate" ("currentHostId", "discordId", "max_length", "max_rank", "max_stars", "min_length", "min_rank", "min_stars", "mp_link") SELECT "currentHostId", "discordId", "max_length", "max_rank", "max_stars", "min_length", "min_rank", "min_stars", "mp_link" FROM "AutoHostRotate";
+DROP TABLE "AutoHostRotate";
+ALTER TABLE "new_AutoHostRotate" RENAME TO "AutoHostRotate";
+CREATE UNIQUE INDEX "AutoHostRotate_currentHostId_key" ON "AutoHostRotate"("currentHostId");
+PRAGMA foreign_key_check;
+PRAGMA foreign_keys=ON;

--- a/prisma/migrations/20220526213114_pr_42/migration.sql
+++ b/prisma/migrations/20220526213114_pr_42/migration.sql
@@ -1,0 +1,178 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `token_access_token` on the `User` table. All the data in the column will be lost.
+  - You are about to drop the column `token_expires_in` on the `User` table. All the data in the column will be lost.
+  - You are about to drop the column `token_refresh_token` on the `User` table. All the data in the column will be lost.
+  - You are about to drop the column `token_type` on the `User` table. All the data in the column will be lost.
+  - You are about to drop the column `warmedUp` on the `TeamInMatch` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "Mappool" ADD COLUMN "round_acronym" TEXT;
+ALTER TABLE "Mappool" ADD COLUMN "round_name" TEXT;
+ALTER TABLE "Mappool" ADD COLUMN "tournament_acronym" TEXT;
+ALTER TABLE "Mappool" ADD COLUMN "tournament_iteration" TEXT;
+ALTER TABLE "Mappool" ADD COLUMN "tournament_name" TEXT;
+
+-- CreateTable
+CREATE TABLE "Global" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "ties" INTEGER NOT NULL DEFAULT 0
+);
+
+-- CreateTable
+CREATE TABLE "OsuOauth" (
+    "discord_id" TEXT NOT NULL PRIMARY KEY,
+    "access_token" TEXT NOT NULL,
+    "expires_in" INTEGER NOT NULL,
+    "refresh_token" TEXT NOT NULL,
+    "type" TEXT NOT NULL,
+    CONSTRAINT "OsuOauth_discord_id_fkey" FOREIGN KEY ("discord_id") REFERENCES "User" ("discord_id") ON DELETE RESTRICT ON UPDATE CASCADE
+);
+INSERT INTO "OsuOauth" ("discord_id", "access_token", "expires_in", "refresh_token", "type") SELECT "discord_id", "token_access_token", "token_expires_in", "token_refresh_token", "token_type" FROM "User";
+
+-- CreateTable
+CREATE TABLE "DiscordOauth" (
+    "discord_id" TEXT NOT NULL PRIMARY KEY,
+    "access_token" TEXT NOT NULL,
+    "expires_in" INTEGER NOT NULL,
+    "refresh_token" TEXT NOT NULL,
+    "type" TEXT NOT NULL,
+    "scope" TEXT NOT NULL,
+    CONSTRAINT "DiscordOauth_discord_id_fkey" FOREIGN KEY ("discord_id") REFERENCES "User" ("discord_id") ON DELETE RESTRICT ON UPDATE CASCADE
+);
+
+-- CreateTable
+CREATE TABLE "QualifierRound" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "mappoolId" INTEGER NOT NULL,
+    CONSTRAINT "QualifierRound_mappoolId_fkey" FOREIGN KEY ("mappoolId") REFERENCES "Mappool" ("id") ON DELETE RESTRICT ON UPDATE CASCADE
+);
+
+-- CreateTable
+CREATE TABLE "QualifierMatch" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "map_index" INTEGER NOT NULL DEFAULT 0
+);
+
+-- CreateTable
+CREATE TABLE "TeamInQualifierMatch" (
+    "teamId" INTEGER NOT NULL,
+    "matchId" INTEGER NOT NULL,
+
+    PRIMARY KEY ("teamId", "matchId"),
+    CONSTRAINT "TeamInQualifierMatch_teamId_fkey" FOREIGN KEY ("teamId") REFERENCES "Team" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+    CONSTRAINT "TeamInQualifierMatch_matchId_fkey" FOREIGN KEY ("matchId") REFERENCES "QualifierMatch" ("id") ON DELETE RESTRICT ON UPDATE CASCADE
+);
+
+-- RedefineTables
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_Match" (
+    "id" INTEGER NOT NULL,
+    "message_id" TEXT,
+    "channel_id" TEXT,
+    "mp_link" TEXT,
+    "waiting_on" INTEGER,
+    "roundId" INTEGER NOT NULL,
+    "state" INTEGER NOT NULL,
+    "scrim" BOOLEAN NOT NULL DEFAULT false,
+
+    PRIMARY KEY ("id", "roundId"),
+    CONSTRAINT "Match_roundId_fkey" FOREIGN KEY ("roundId") REFERENCES "Round" ("id") ON DELETE RESTRICT ON UPDATE CASCADE
+);
+INSERT INTO "new_Match" ("channel_id", "id", "message_id", "mp_link", "roundId", "state", "waiting_on") SELECT "channel_id", "id", "message_id", "mp_link", "roundId", "state", "waiting_on" FROM "Match";
+DROP TABLE "Match";
+ALTER TABLE "new_Match" RENAME TO "Match";
+CREATE TABLE "new_User" (
+    "discord_id" TEXT NOT NULL PRIMARY KEY,
+    "discord_avatar" TEXT NOT NULL,
+    "discord_avatarURL" TEXT NOT NULL,
+    "discord_bot" BOOLEAN NOT NULL,
+    "discord_createdTimestamp" INTEGER NOT NULL,
+    "discord_defaultAvatarURL" TEXT NOT NULL,
+    "discord_discriminator" TEXT NOT NULL,
+    "discord_displayAvatarURL" TEXT NOT NULL,
+    "discord_flags" INTEGER NOT NULL,
+    "discord_system" BOOLEAN NOT NULL,
+    "discord_tag" TEXT NOT NULL,
+    "discord_username" TEXT NOT NULL,
+    "osu_id" INTEGER NOT NULL,
+    "osu_username" TEXT NOT NULL,
+    "osu_country_code" TEXT NOT NULL,
+    "osu_country_name" TEXT NOT NULL,
+    "osu_cover_url" TEXT NOT NULL,
+    "osu_ranked_score" INTEGER NOT NULL,
+    "osu_play_count" INTEGER NOT NULL,
+    "osu_total_score" INTEGER NOT NULL,
+    "osu_pp_rank" INTEGER NOT NULL,
+    "osu_level" INTEGER NOT NULL,
+    "osu_level_progress" INTEGER NOT NULL,
+    "osu_hit_accuracy" REAL NOT NULL,
+    "osu_pp" REAL NOT NULL
+);
+INSERT INTO "new_User" ("discord_avatar", "discord_avatarURL", "discord_bot", "discord_createdTimestamp", "discord_defaultAvatarURL", "discord_discriminator", "discord_displayAvatarURL", "discord_flags", "discord_id", "discord_system", "discord_tag", "discord_username", "osu_country_code", "osu_country_name", "osu_cover_url", "osu_hit_accuracy", "osu_id", "osu_level", "osu_level_progress", "osu_play_count", "osu_pp", "osu_pp_rank", "osu_ranked_score", "osu_total_score", "osu_username") SELECT "discord_avatar", "discord_avatarURL", "discord_bot", "discord_createdTimestamp", "discord_defaultAvatarURL", "discord_discriminator", "discord_displayAvatarURL", "discord_flags", "discord_id", "discord_system", "discord_tag", "discord_username", "osu_country_code", "osu_country_name", "osu_cover_url", "osu_hit_accuracy", "osu_id", "osu_level", "osu_level_progress", "osu_play_count", "osu_pp", "osu_pp_rank", "osu_ranked_score", "osu_total_score", "osu_username" FROM "User";
+DROP TABLE "User";
+ALTER TABLE "new_User" RENAME TO "User";
+CREATE TABLE "new_Tournament" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "acronym" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "color" TEXT NOT NULL,
+    "force_nf" BOOLEAN NOT NULL,
+    "icon_url" TEXT NOT NULL,
+    "score_mode" INTEGER NOT NULL,
+    "team_mode" INTEGER NOT NULL,
+    "team_size" INTEGER NOT NULL,
+    "XvX_mode" INTEGER NOT NULL,
+    "allow_registrations" BOOLEAN NOT NULL,
+    "Guild_id" TEXT,
+    "delete_warning" BOOLEAN,
+    "double_pick" INTEGER NOT NULL DEFAULT 1,
+    "double_ban" INTEGER NOT NULL DEFAULT 1,
+    "multiplier_nm" REAL NOT NULL DEFAULT 1.0,
+    "multiplier_hd" REAL NOT NULL DEFAULT 1.0,
+    "multiplier_hr" REAL NOT NULL DEFAULT 1.0,
+    "multiplier_ez" REAL NOT NULL DEFAULT 1.5,
+    "multiplier_fl" REAL NOT NULL DEFAULT 1.0,
+    CONSTRAINT "Tournament_Guild_id_fkey" FOREIGN KEY ("Guild_id") REFERENCES "Guild" ("guild_id") ON DELETE SET NULL ON UPDATE CASCADE
+);
+INSERT INTO "new_Tournament" ("Guild_id", "XvX_mode", "acronym", "allow_registrations", "color", "delete_warning", "double_ban", "double_pick", "force_nf", "icon_url", "id", "name", "score_mode", "team_mode", "team_size") SELECT "Guild_id", "XvX_mode", "acronym", "allow_registrations", "color", "delete_warning", "double_ban", "double_pick", "force_nf", "icon_url", "id", "name", "score_mode", "team_mode", "team_size" FROM "Tournament";
+DROP TABLE "Tournament";
+ALTER TABLE "new_Tournament" RENAME TO "Tournament";
+CREATE TABLE "new_Team" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "name" TEXT NOT NULL,
+    "icon_url" TEXT NOT NULL,
+    "color" TEXT NOT NULL,
+    "tournamentId" INTEGER NOT NULL,
+    "scrim" BOOLEAN NOT NULL DEFAULT false,
+    CONSTRAINT "Team_tournamentId_fkey" FOREIGN KEY ("tournamentId") REFERENCES "Tournament" ("id") ON DELETE RESTRICT ON UPDATE CASCADE
+);
+INSERT INTO "new_Team" ("color", "icon_url", "id", "name", "tournamentId") SELECT "color", "icon_url", "id", "name", "tournamentId" FROM "Team";
+DROP TABLE "Team";
+ALTER TABLE "new_Team" RENAME TO "Team";
+CREATE TABLE "new_TeamInMatch" (
+    "matchId" INTEGER NOT NULL,
+    "teamId" INTEGER NOT NULL,
+    "roundId" INTEGER NOT NULL,
+    "score" INTEGER NOT NULL,
+    "roll" INTEGER,
+    "pick_order" INTEGER,
+    "ban_order" INTEGER,
+    "warmed_up" BOOLEAN NOT NULL DEFAULT false,
+    "winner" BOOLEAN,
+
+    PRIMARY KEY ("teamId", "matchId"),
+    CONSTRAINT "TeamInMatch_teamId_fkey" FOREIGN KEY ("teamId") REFERENCES "Team" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "TeamInMatch_matchId_roundId_fkey" FOREIGN KEY ("matchId", "roundId") REFERENCES "Match" ("id", "roundId") ON DELETE CASCADE ON UPDATE CASCADE
+);
+ALTER TABLE "TeamInMatch" RENAME COLUMN "warmedUp" TO "warmed_up";
+INSERT INTO "new_TeamInMatch" ("ban_order", "matchId", "pick_order", "roll", "roundId", "score", "teamId", "warmed_up", "winner") SELECT "ban_order", "matchId", "pick_order", "roll", "roundId", "score", "teamId", "warmed_up", "winner" FROM "TeamInMatch";
+DROP TABLE "TeamInMatch";
+ALTER TABLE "new_TeamInMatch" RENAME TO "TeamInMatch";
+PRAGMA foreign_key_check;
+PRAGMA foreign_keys=ON;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "QualifierRound_mappoolId_key" ON "QualifierRound"("mappoolId");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -10,6 +10,11 @@ datasource db {
   url      = env("DATABASE_URL")
 }
 
+model Global {
+  id   Int @id @default(autoincrement())
+  ties Int @default(0)
+}
+
 model Map {
   beatmap_id           String      @id
   fetch_time           DateTime    @default(now())
@@ -70,10 +75,17 @@ model MapInPool {
 }
 
 model Mappool {
-  id     Int         @id @default(autoincrement())
-  maps   MapInPool[]
-  global Boolean     @default(false)
-  Round  Round?
+  id        Int             @id @default(autoincrement())
+  maps      MapInPool[]
+  global    Boolean         @default(false)
+  Round     Round?
+  Qualifier QualifierRound?
+
+  tournament_name      String?
+  tournament_acronym   String?
+  tournament_iteration String?
+  round_name           String?
+  round_acronym        String?
 }
 
 model Round {
@@ -109,11 +121,17 @@ model Tournament {
   delete_warning      Boolean?
   double_pick         Int      @default(1) // 0: No double picking; 1: Only double picking NM; 2 Double Picking allowed
   double_ban          Int      @default(1) // 0: No double picking; 1: Only double picking NM; 2 Double Picking allowed
-  Team                Team[]
+  Teams               Team[]
+
+  multiplier_nm Float @default(1.0)
+  multiplier_hd Float @default(1.0)
+  multiplier_hr Float @default(1.0)
+  multiplier_ez Float @default(1.5)
+  multiplier_fl Float @default(1.0)
 }
 
 model User {
-  discord_id               String       @id
+  discord_id               String          @id
   discord_avatar           String
   discord_avatarURL        String
   discord_bot              Boolean
@@ -138,11 +156,29 @@ model User {
   osu_level_progress       Int
   osu_hit_accuracy         Float
   osu_pp                   Float
-  token_access_token       String
-  token_expires_in         Int
-  token_refresh_token      String
-  token_type               String
-  in_teams                 UserInTeam[]
+  OsuOauth                 OsuOauth?
+  DiscordOauth             DiscordOauth?
+  inTeams                  UserInTeam[]
+  OwnerOfLobby             AutoHostRotate?
+}
+
+model OsuOauth {
+  User          User   @relation(fields: [discord_id], references: [discord_id])
+  discord_id    String @id
+  access_token  String
+  expires_in    Int
+  refresh_token String
+  type          String
+}
+
+model DiscordOauth {
+  User          User   @relation(fields: [discord_id], references: [discord_id])
+  discord_id    String @id
+  access_token  String
+  expires_in    Int
+  refresh_token String
+  type          String
+  scope         String
 }
 
 model Guild {
@@ -156,14 +192,16 @@ model Guild {
 }
 
 model Team {
-  id           Int           @id @default(autoincrement())
-  name         String
-  icon_url     String
-  color        String
-  members      UserInTeam[]
-  tournament   Tournament    @relation(fields: [tournamentId], references: [id])
-  tournamentId Int
-  TeamInMatch  TeamInMatch[]
+  id               Int                    @id @default(autoincrement())
+  name             String
+  icon_url         String
+  color            String
+  Members          UserInTeam[]
+  Tournament       Tournament             @relation(fields: [tournamentId], references: [id])
+  tournamentId     Int
+  scrim            Boolean                @default(false)
+  InBracketMatches TeamInMatch[]
+  InQualifiers     TeamInQualifierMatch[]
 }
 
 model UserInTeam {
@@ -187,6 +225,7 @@ model Match {
   roundId     Int
   MapsInMatch MapInMatch[]
   state       Int
+  scrim       Boolean       @default(false)
 
   @@id([id, roundId])
 }
@@ -201,7 +240,7 @@ model TeamInMatch {
   roll       Int?
   pick_order Int?
   ban_order  Int?
-  warmedUp   Boolean      @default(false)
+  warmed_up  Boolean      @default(false)
   Bans       MapInMatch[] @relation("banned")
   Wins       MapInMatch[] @relation("won")
   Picks      MapInMatch[] @relation("picked")
@@ -230,4 +269,50 @@ model MapInMatch {
   wonByTeamId     Int?
   wonByMatchId    Int?
   @@id([mapIdentifier, matchId])
+}
+
+model QualifierRound {
+  id        Int     @id @default(autoincrement())
+  Mappool   Mappool @relation(fields: [mappoolId], references: [id])
+  mappoolId Int     @unique
+}
+
+model QualifierMatch {
+  id        Int                    @id @default(autoincrement())
+  Teams     TeamInQualifierMatch[]
+  map_index Int                    @default(0)
+}
+
+model TeamInQualifierMatch {
+  Team    Team           @relation(fields: [teamId], references: [id])
+  teamId  Int
+  Match   QualifierMatch @relation(fields: [matchId], references: [id])
+  matchId Int
+
+  @@id([teamId, matchId])
+}
+
+model AutoHostRotate {
+  Owner     User   @relation(fields: [discordId], references: [discord_id])
+  discordId String @id
+  mp_link   String
+
+  min_stars     Float?
+  max_stars     Float?
+  min_length    Int?
+  max_length    Int?
+  min_rank      Int?
+  max_rank      Int?
+  playerOrder   AutoHostRotatePlayer[] @relation("queue")
+  CurrentHost   AutoHostRotatePlayer?  @relation("current", fields: [currentHostId], references: [id])
+  currentHostId Int?                   @unique
+}
+
+model AutoHostRotatePlayer {
+  id       Int             @id
+  username String
+  rank     Int
+  lobbyId  String
+  InLobby  AutoHostRotate  @relation("queue", fields: [lobbyId], references: [discordId], onDelete: Cascade)
+  HostIn   AutoHostRotate? @relation("current")
 }


### PR DESCRIPTION
## Additions
* Add `AutoHostRotate` & `AutoHostRotatePlayer` models in prep for auto host rotate 
* Add `OsuOauth` model to handle osu! oauth tokens
* Add `DiscordOauth` model in prep for Discord authentication
* Add `Global` model, to hold global variables, like total tie-count
* Add `QualifierRound`, `MapInQualifiers`, `QualifierMatch`, and `TeamInQualifierMatch` model to handle qualifier matches

## Movements
* **Move** `token_access_token` and other osu! oauth token objects into a new model

## Changes
* Change `Team.tournament` to `Team.Tournament` for standardization
* Change `User.in_teams` to `User.inTeams` for standardization
* Change `Team.TeamInMatch` to `Team.InBracketMatches`
* Change `Team` and `Match` to include a Scrim argument
* Change `Team.warmedUp` to `Team.warmed_up` for standardization
* Change `Team.members` to `Team.Members` for standardization
* Change `Tournament` model to contain mod multipliers for NM, HD, HR, EZ, FL
* Change `Tournament.Team` to `Tournament.Teams`
* Change `Mappool` model to include a Optional Tournament Name, Optional Tournament Acronym, Optional Tournament Iteration, Optional Round Name, Optional Round Acronym, Optional Tournament Iteration