### PR TITLE
More DB

### DIFF
--- a/bancho/dm-commands/invite.js
+++ b/bancho/dm-commands/invite.js
@@ -20,7 +20,7 @@ module.exports = {
 					not: 3,
 				},
 
-				teams: {
+				Teams: {
 					some: {
 						Team: {
 							Members: {

--- a/bancho/match-types/bracket/Match.js
+++ b/bancho/match-types/bracket/Match.js
@@ -101,7 +101,7 @@ class MatchManager {
 		for (let team of dbTeams) {
 			let users = await prisma.user.findMany({
 				where: {
-					inTeams: {
+					InTeams: {
 						some: {
 							teamId: team.id,
 						},
@@ -142,7 +142,7 @@ class MatchManager {
 		for (const mapInMatch of mappool) {
 			let map = await prisma.map.findFirst({
 				where: {
-					in_pools: {
+					InPools: {
 						some: {
 							InMatches: {
 								some: {

--- a/bancho/match-types/bracket/Match.js
+++ b/bancho/match-types/bracket/Match.js
@@ -216,10 +216,7 @@ class MatchManager {
 		// Update db object
 		await prisma.match.update({
 			where: {
-				id_roundId: {
-					id: this.id,
-					roundId: this.round.id,
-				},
+				id: this.id,
 			},
 			data: {
 				mp_link: this.lobby.getHistoryUrl(),
@@ -936,10 +933,7 @@ class MatchManager {
 		await new Promise((resolve) => setTimeout(resolve, prismaTimeout));
 		await prisma.match.update({
 			where: {
-				id_roundId: {
-					id: this.id,
-					roundId: this.round.id,
-				},
+				id: this.id,
 			},
 			data: {
 				waiting_on: num,
@@ -959,10 +953,7 @@ class MatchManager {
 		await new Promise((resolve) => setTimeout(resolve, prismaTimeout));
 		await prisma.match.update({
 			where: {
-				id_roundId: {
-					id: this.id,
-					roundId: this.round.id,
-				},
+				id: this.id,
 			},
 			data: {
 				state: state,

--- a/bancho/match-types/bracket/Match.js
+++ b/bancho/match-types/bracket/Match.js
@@ -231,7 +231,7 @@ class MatchManager {
 		await this.lobby.setSettings(
 			this.tournament.team_mode,
 			this.tournament.score_mode == 4 ? 3 : this.tournament.score_mode,
-			this.tournament.XvX_mode * 2 + 1
+			this.tournament.x_v_x_mode * 2 + 1
 		);
 
 		// Do onJoin for players currently in the lobby
@@ -332,7 +332,7 @@ class MatchManager {
 			let badTeams = [];
 			for (const key in lobbyCount) {
 				let teamCount = lobbyCount[key];
-				if (teamCount != this.tournament.XvX_mode) {
+				if (teamCount != this.tournament.x_v_x_mode) {
 					badTeams.push(key);
 				}
 			}

--- a/discord/buttons/rounds_list.js
+++ b/discord/buttons/rounds_list.js
@@ -52,7 +52,7 @@ module.exports = {
 			for (const map of pool) {
 				let data = await prisma.map.findFirst({
 					where: {
-						in_pools: {
+						inPools: {
 							some: {
 								mappoolId: map.mappoolId,
 							},

--- a/discord/buttons/start_match.js
+++ b/discord/buttons/start_match.js
@@ -50,7 +50,7 @@ module.exports = {
 		// Check that the team is not already in a running match
 		let duplicateCheck = await prisma.match.findFirst({
 			where: {
-				teams: {
+				Teams: {
 					some: {
 						OR: [
 							{

--- a/discord/buttons/start_match.js
+++ b/discord/buttons/start_match.js
@@ -139,7 +139,7 @@ module.exports = {
 
 		let players = await prisma.user.findMany({
 			where: {
-				inTeams: {
+				InTeams: {
 					some: {
 						Team: {
 							InBracketMatches: {

--- a/discord/buttons/start_match.js
+++ b/discord/buttons/start_match.js
@@ -127,10 +127,7 @@ module.exports = {
 		}
 		await prisma.match.update({
 			where: {
-				id_roundId: {
-					id: match.id,
-					roundId: round.id,
-				},
+				id: this.id,
 			},
 			data: {
 				state: 3,
@@ -206,10 +203,7 @@ module.exports = {
 
 		await prisma.match.update({
 			where: {
-				id_roundId: {
-					id: match.id,
-					roundId: round.id,
-				},
+				id: this.id,
 			},
 			data: {
 				message_id: message.id,

--- a/discord/buttons/team_list.js
+++ b/discord/buttons/team_list.js
@@ -27,7 +27,7 @@ module.exports = {
 		for (const team of teams) {
 			let membersInTeam = await prisma.user.findMany({
 				where: {
-					inTeams: {
+					InTeams: {
 						some: {
 							teamId: team.id,
 						},
@@ -105,7 +105,7 @@ module.exports = {
 			let teamString = "";
 			let members = await prisma.user.findMany({
 				where: {
-					inTeams: {
+					InTeams: {
 						some: {
 							teamId: team.id,
 						},

--- a/discord/buttons/view_match.js
+++ b/discord/buttons/view_match.js
@@ -42,7 +42,7 @@ module.exports = {
 			let teamString = "";
 			let members = await prisma.user.findMany({
 				where: {
-					inTeams: {
+					InTeams: {
 						some: {
 							teamId: team.id,
 						},

--- a/discord/commands/deregister.js
+++ b/discord/commands/deregister.js
@@ -32,7 +32,7 @@ module.exports = {
 		}
 		let members = await prisma.user.findMany({
 			where: {
-				inTeams: {
+				InTeams: {
 					some: {
 						teamId: team.id,
 					},

--- a/discord/commands/match/addlink.js
+++ b/discord/commands/match/addlink.js
@@ -23,7 +23,7 @@ module.exports = {
 
 		let matchId = await prisma.match.findFirst({
 			where: {
-				teams: {
+				Teams: {
 					some: {
 						Team: {
 							Members: {

--- a/discord/commands/matches/create.js
+++ b/discord/commands/matches/create.js
@@ -205,7 +205,7 @@ module.exports = {
 			let teamString = "";
 			let members = await prisma.user.findMany({
 				where: {
-					inTeams: {
+					InTeams: {
 						some: {
 							teamId: team.id,
 						},

--- a/discord/commands/matches/create.js
+++ b/discord/commands/matches/create.js
@@ -132,7 +132,6 @@ module.exports = {
 
 		let match = await prisma.match.create({
 			data: {
-				roundId: round.id,
 				id: matches.length + 1,
 				state: 10,
 			},

--- a/discord/commands/team/edit.js
+++ b/discord/commands/team/edit.js
@@ -137,7 +137,7 @@ module.exports = {
 
 		let members = await prisma.user.findMany({
 			where: {
-				inTeams: {
+				InTeams: {
 					some: {
 						teamId: team.id,
 					},

--- a/discord/commands/team/invite.js
+++ b/discord/commands/team/invite.js
@@ -69,7 +69,7 @@ module.exports = {
 
 		let inviterMembers = await prisma.user.findMany({
 			where: {
-				inTeams: {
+				InTeams: {
 					some: {
 						teamId: inviterTeam.id,
 					},
@@ -101,7 +101,7 @@ module.exports = {
 		let duplicateCheck = await prisma.user.findFirst({
 			where: {
 				discord_id: invitee.id,
-				inTeams: {
+				InTeams: {
 					some: {
 						discordId: invitee.id,
 						teamId: inviterTeam.id,

--- a/discord/commands/team/view.js
+++ b/discord/commands/team/view.js
@@ -46,7 +46,7 @@ module.exports = {
 
 		let members = await prisma.user.findMany({
 			where: {
-				inTeams: {
+				InTeams: {
 					some: {
 						teamId: team.id,
 					},

--- a/discord/commands/tournaments/create.js
+++ b/discord/commands/tournaments/create.js
@@ -14,12 +14,16 @@ module.exports = {
 				.setRequired(true)
 		)
 		.addStringOption((option) =>
-			option.setName("name").setDescription("The name for your tournament")
+			option
+				.setName("name")
+				.setDescription("The name for your tournament")
 		)
 		.addIntegerOption((option) =>
 			option
 				.setName("score_mode")
-				.setDescription("Changes the way scores are handled in the lobby")
+				.setDescription(
+					"Changes the way scores are handled in the lobby"
+				)
 				.addChoice("Score", 0)
 				.addChoice("Combo", 1)
 				.addChoice("Accuracy", 2)
@@ -50,7 +54,9 @@ module.exports = {
 		.addIntegerOption((option) =>
 			option
 				.setName("x_v_x_mode")
-				.setDescription("How many players are playing against eachother")
+				.setDescription(
+					"How many players are playing against eachother"
+				)
 				.setMinValue(1)
 				.setMaxValue(8)
 		)
@@ -62,7 +68,9 @@ module.exports = {
 		.addStringOption((option) =>
 			option
 				.setName("color")
-				.setDescription("Set a custom color for your tournament e.g.(#0EB8B9)")
+				.setDescription(
+					"Set a custom color for your tournament e.g.(#0EB8B9)"
+				)
 		),
 	async execute(interaction) {
 		await interaction.deferReply({ ephemeral: true });
@@ -97,7 +105,7 @@ module.exports = {
 				interaction.options.getString("icon_url") ??
 				"https://yagami.clxxiii.dev/static/yagami%20var.png",
 			allow_registrations: false,
-			XvX_mode: interaction.options.getInteger("x_v_x_mode") || 1,
+			x_v_x_mode: interaction.options.getInteger("x_v_x_mode") || 1,
 			Guild_id: interaction.guildId,
 		};
 

--- a/discord/commands/tournaments/edit.js
+++ b/discord/commands/tournaments/edit.js
@@ -138,10 +138,6 @@ module.exports = {
 
 		options.forEach((element) => {
 			let prop = element.name;
-			// Temporary fix
-			if (prop === "x_v_x_mode") {
-				prop = "XvX_mode";
-			}
 			tournament[prop] = element.value;
 		});
 

--- a/prisma/migrations/20220528042641_pr_49/migration.sql
+++ b/prisma/migrations/20220528042641_pr_49/migration.sql
@@ -1,0 +1,104 @@
+/*
+  Warnings:
+
+  - The primary key for the `Match` table will be changed. If it partially fails, the table could be left without primary key constraint.
+  - You are about to drop the column `roundId` on the `TeamInMatch` table. All the data in the column will be lost.
+  - You are about to drop the column `roundId` on the `MapInMatch` table. All the data in the column will be lost.
+  - You are about to drop the column `XvX_mode` on the `Tournament` table. All the data in the column will be lost.
+  - Added the required column `x_v_x_mode` to the `Tournament` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- CreateTable
+CREATE TABLE "ScrimSettings" (
+    "matchId" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "bans" INTEGER NOT NULL,
+    "best_of" INTEGER NOT NULL,
+    CONSTRAINT "ScrimSettings_matchId_fkey" FOREIGN KEY ("matchId") REFERENCES "Match" ("id") ON DELETE RESTRICT ON UPDATE CASCADE
+);
+
+-- RedefineTables
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_Match" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "start_time" DATETIME,
+    "message_id" TEXT,
+    "channel_id" TEXT,
+    "mp_link" TEXT,
+    "waiting_on" INTEGER,
+    "roundId" INTEGER,
+    "state" INTEGER NOT NULL,
+    "scrim" BOOLEAN NOT NULL DEFAULT false,
+    CONSTRAINT "Match_roundId_fkey" FOREIGN KEY ("roundId") REFERENCES "Round" ("id") ON DELETE SET NULL ON UPDATE CASCADE
+);
+INSERT INTO "new_Match" ("channel_id", "id", "message_id", "mp_link", "roundId", "scrim", "state", "waiting_on") SELECT "channel_id", "id", "message_id", "mp_link", "roundId", "scrim", "state", "waiting_on" FROM "Match";
+DROP TABLE "Match";
+ALTER TABLE "new_Match" RENAME TO "Match";
+CREATE TABLE "new_TeamInMatch" (
+    "matchId" INTEGER NOT NULL,
+    "teamId" INTEGER NOT NULL,
+    "score" INTEGER NOT NULL,
+    "roll" INTEGER,
+    "pick_order" INTEGER,
+    "ban_order" INTEGER,
+    "warmed_up" BOOLEAN NOT NULL DEFAULT false,
+    "winner" BOOLEAN,
+
+    PRIMARY KEY ("teamId", "matchId"),
+    CONSTRAINT "TeamInMatch_teamId_fkey" FOREIGN KEY ("teamId") REFERENCES "Team" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "TeamInMatch_matchId_fkey" FOREIGN KEY ("matchId") REFERENCES "Match" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+INSERT INTO "new_TeamInMatch" ("ban_order", "matchId", "pick_order", "roll", "score", "teamId", "warmed_up", "winner") SELECT "ban_order", "matchId", "pick_order", "roll", "score", "teamId", "warmed_up", "winner" FROM "TeamInMatch";
+DROP TABLE "TeamInMatch";
+ALTER TABLE "new_TeamInMatch" RENAME TO "TeamInMatch";
+CREATE TABLE "new_MapInMatch" (
+    "matchId" INTEGER NOT NULL,
+    "mapIdentifier" TEXT NOT NULL,
+    "poolId" INTEGER NOT NULL,
+    "bannedByTeamId" INTEGER,
+    "bannedByMatchId" INTEGER,
+    "pickedByTeamId" INTEGER,
+    "pickedByMatchId" INTEGER,
+    "pickNumber" INTEGER,
+    "pickTeamNumber" INTEGER,
+    "wonByTeamId" INTEGER,
+    "wonByMatchId" INTEGER,
+
+    PRIMARY KEY ("mapIdentifier", "matchId"),
+    CONSTRAINT "MapInMatch_mapIdentifier_poolId_fkey" FOREIGN KEY ("mapIdentifier", "poolId") REFERENCES "MapInPool" ("identifier", "mappoolId") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "MapInMatch_matchId_fkey" FOREIGN KEY ("matchId") REFERENCES "Match" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "MapInMatch_bannedByMatchId_bannedByTeamId_fkey" FOREIGN KEY ("bannedByMatchId", "bannedByTeamId") REFERENCES "TeamInMatch" ("matchId", "teamId") ON DELETE SET NULL ON UPDATE CASCADE,
+    CONSTRAINT "MapInMatch_pickedByMatchId_pickedByTeamId_fkey" FOREIGN KEY ("pickedByMatchId", "pickedByTeamId") REFERENCES "TeamInMatch" ("matchId", "teamId") ON DELETE SET NULL ON UPDATE CASCADE,
+    CONSTRAINT "MapInMatch_wonByMatchId_wonByTeamId_fkey" FOREIGN KEY ("wonByMatchId", "wonByTeamId") REFERENCES "TeamInMatch" ("matchId", "teamId") ON DELETE SET NULL ON UPDATE CASCADE
+);
+INSERT INTO "new_MapInMatch" ("bannedByMatchId", "bannedByTeamId", "mapIdentifier", "matchId", "pickNumber", "pickTeamNumber", "pickedByMatchId", "pickedByTeamId", "poolId", "wonByMatchId", "wonByTeamId") SELECT "bannedByMatchId", "bannedByTeamId", "mapIdentifier", "matchId", "pickNumber", "pickTeamNumber", "pickedByMatchId", "pickedByTeamId", "poolId", "wonByMatchId", "wonByTeamId" FROM "MapInMatch";
+DROP TABLE "MapInMatch";
+ALTER TABLE "new_MapInMatch" RENAME TO "MapInMatch";
+CREATE TABLE "new_Tournament" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "acronym" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "color" TEXT NOT NULL,
+    "force_nf" BOOLEAN NOT NULL,
+    "icon_url" TEXT NOT NULL,
+    "score_mode" INTEGER NOT NULL,
+    "team_mode" INTEGER NOT NULL,
+    "team_size" INTEGER NOT NULL,
+    "x_v_x_mode" INTEGER NOT NULL,
+    "allow_registrations" BOOLEAN NOT NULL,
+    "Guild_id" TEXT,
+    "delete_warning" BOOLEAN,
+    "double_pick" INTEGER NOT NULL DEFAULT 1,
+    "double_ban" INTEGER NOT NULL DEFAULT 1,
+    "multiplier_nm" REAL NOT NULL DEFAULT 1.0,
+    "multiplier_hd" REAL NOT NULL DEFAULT 1.0,
+    "multiplier_hr" REAL NOT NULL DEFAULT 1.0,
+    "multiplier_ez" REAL NOT NULL DEFAULT 1.5,
+    "multiplier_fl" REAL NOT NULL DEFAULT 1.0,
+    CONSTRAINT "Tournament_Guild_id_fkey" FOREIGN KEY ("Guild_id") REFERENCES "Guild" ("guild_id") ON DELETE SET NULL ON UPDATE CASCADE
+);
+ALTER TABLE "Tournament" RENAME COLUMN "XvX_mode" TO "x_v_x_mode";
+INSERT INTO "new_Tournament" ("Guild_id", "acronym", "allow_registrations", "color", "delete_warning", "double_ban", "double_pick", "force_nf", "icon_url", "id", "multiplier_ez", "multiplier_fl", "multiplier_hd", "multiplier_hr", "multiplier_nm", "name", "score_mode", "team_mode", "team_size", "x_v_x_mode") SELECT "Guild_id", "acronym", "allow_registrations", "color", "delete_warning", "double_ban", "double_pick", "force_nf", "icon_url", "id", "multiplier_ez", "multiplier_fl", "multiplier_hd", "multiplier_hr", "multiplier_nm", "name", "score_mode", "team_mode", "team_size", "x_v_x_mode" FROM "Tournament";
+DROP TABLE "Tournament";
+ALTER TABLE "new_Tournament" RENAME TO "Tournament";
+PRAGMA foreign_key_check;
+PRAGMA foreign_keys=ON;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -76,7 +76,7 @@ model MapInPool {
 
 model Mappool {
   id        Int             @id @default(autoincrement())
-  maps      MapInPool[]
+  Maps      MapInPool[]
   global    Boolean         @default(false)
   Round     Round?
   Qualifier QualifierRound?
@@ -97,7 +97,7 @@ model Round {
   delete_warning String?
   show_mappool   Boolean
   Match          Match[]
-  tournament     Tournament @relation(fields: [tournamentId], references: [id], onDelete: Cascade)
+  Tournament     Tournament @relation(fields: [tournamentId], references: [id], onDelete: Cascade)
   tournamentId   Int
   mappool        Mappool?   @relation(fields: [mappoolId], references: [id])
   mappoolId      Int?       @unique
@@ -158,7 +158,7 @@ model User {
   osu_pp                   Float
   OsuOauth                 OsuOauth?
   DiscordOauth             DiscordOauth?
-  inTeams                  UserInTeam[]
+  InTeams                  UserInTeam[]
   OwnerOfLobby             AutoHostRotate?
 }
 
@@ -187,7 +187,7 @@ model Guild {
   linked_role           String?
   player_role           String?
   match_results_channel String?
-  tournaments           Tournament[]
+  Tournaments           Tournament[]
   active_tournament     Int?
 }
 
@@ -206,7 +206,7 @@ model Team {
 
 model UserInTeam {
   discordId      String
-  user           User     @relation(fields: [discordId], references: [discord_id])
+  User           User     @relation(fields: [discordId], references: [discord_id])
   Team           Team     @relation(fields: [teamId], references: [id])
   teamId         Int
   delete_warning Boolean?
@@ -216,7 +216,7 @@ model UserInTeam {
 
 model Match {
   id            Int            @id @default(autoincrement())
-  teams         TeamInMatch[]
+  Teams         TeamInMatch[]
   start_time    DateTime?
   message_id    String?
   channel_id    String?
@@ -240,7 +240,7 @@ model ScrimSettings {
 model TeamInMatch {
   matchId    Int
   teamId     Int
-  match      Match        @relation(fields: [matchId], references: [id], onDelete: Cascade)
+  Match      Match        @relation(fields: [matchId], references: [id], onDelete: Cascade)
   Team       Team         @relation(fields: [teamId], references: [id], onDelete: Cascade)
   score      Int
   roll       Int?
@@ -270,7 +270,7 @@ model MapInMatch {
   pickedByMatchId Int?
   pickNumber      Int?
   pickTeamNumber  Int?
-  won_by          TeamInMatch? @relation(fields: [wonByMatchId, wonByTeamId], references: [matchId, teamId], name: "won")
+  WonBy           TeamInMatch? @relation(fields: [wonByMatchId, wonByTeamId], references: [matchId, teamId], name: "won")
   wonByTeamId     Int?
   wonByMatchId    Int?
   @@id([mapIdentifier, matchId])
@@ -308,7 +308,7 @@ model AutoHostRotate {
   max_length    Int?
   min_rank      Int?
   max_rank      Int?
-  playerOrder   AutoHostRotatePlayer[] @relation("queue")
+  PlayerOrder   AutoHostRotatePlayer[] @relation("queue")
   CurrentHost   AutoHostRotatePlayer?  @relation("current", fields: [currentHostId], references: [id])
   currentHostId Int?                   @unique
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -59,7 +59,7 @@ model Map {
   total_length         String?
   version              String?
   video                String?
-  in_pools             MapInPool[]
+  InPools              MapInPool[]
 }
 
 model MapInPool {
@@ -113,7 +113,7 @@ model Tournament {
   score_mode          Int
   team_mode           Int
   team_size           Int
-  XvX_mode            Int
+  x_v_x_mode          Int
   allow_registrations Boolean
   rounds              Round[]
   Guild               Guild?   @relation(fields: [Guild_id], references: [guild_id])
@@ -215,26 +215,32 @@ model UserInTeam {
 }
 
 model Match {
-  id          Int
-  teams       TeamInMatch[]
-  message_id  String?
-  channel_id  String?
-  mp_link     String?
-  waiting_on  Int? // Index of team in teams array
-  Round       Round         @relation(fields: [roundId], references: [id])
-  roundId     Int
-  MapsInMatch MapInMatch[]
-  state       Int
-  scrim       Boolean       @default(false)
+  id            Int            @id @default(autoincrement())
+  teams         TeamInMatch[]
+  start_time    DateTime?
+  message_id    String?
+  channel_id    String?
+  mp_link       String?
+  waiting_on    Int? // Index of team in teams array
+  Round         Round?         @relation(fields: [roundId], references: [id])
+  roundId       Int?
+  ScrimSettings ScrimSettings?
+  MapsInMatch   MapInMatch[]
+  state         Int
+  scrim         Boolean        @default(false)
+}
 
-  @@id([id, roundId])
+model ScrimSettings {
+  matchId Int   @id
+  Match   Match @relation(fields: [matchId], references: [id])
+  bans    Int
+  best_of Int
 }
 
 model TeamInMatch {
   matchId    Int
   teamId     Int
-  roundId    Int
-  match      Match        @relation(fields: [matchId, roundId], references: [id, roundId], onDelete: Cascade)
+  match      Match        @relation(fields: [matchId], references: [id], onDelete: Cascade)
   Team       Team         @relation(fields: [teamId], references: [id], onDelete: Cascade)
   score      Int
   roll       Int?
@@ -251,9 +257,8 @@ model TeamInMatch {
 
 model MapInMatch {
   Map           MapInPool @relation(fields: [mapIdentifier, poolId], references: [identifier, mappoolId], onDelete: Cascade)
-  Match         Match     @relation(fields: [matchId, roundId], references: [id, roundId], onDelete: Cascade)
+  Match         Match     @relation(fields: [matchId], references: [id], onDelete: Cascade)
   matchId       Int
-  roundId       Int
   mapIdentifier String
   poolId        Int
 


### PR DESCRIPTION
# Renames
* `Map.in_pools` to `Map.InPools`
* `User.inTeams` to `User.InTeams`
* `Guild.tournaments` to `Guild.Tournaments`
* `Tournament.XvX_mode` to `Tournament.x_v_x_mode`
* `UserInTeam.user` to `UserInTeam.User`
* `MapInPool.map` to `MapInPool.Map`
* `Round.tournament` to `Round.Tournament`
* `Round.mappool` to `Round.Mappool`
* `Match.teams` to `Match.Teams`
* `TeamInMatch.Match` to `TeamInMatch.Match`
* `MapInMatch.won_by` to `MapInMatch.WonBy`
* `AutoHostRotate.playerOrder` to `AutoHostRotate.PlayerOrder`

# Changes
* Change `Match` ID to be a single primary key on auto-increment, 
* Add an optional `start_time` property to the Match object
* Make `Match.Round` and `Match.roundId` optional, for scrims
* Add `ScrimSettings` to `Match`

# Additions
* Add `ScrimSettings` model that contains `best_of` etc. information when a round isn't present